### PR TITLE
Add API prefix to public endpoints

### DIFF
--- a/backend/backend/src/main/java/com/softserve/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/com/softserve/config/SecurityConfig.java
@@ -61,15 +61,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private static final String ROOM_TYPES_ENDPOINT = "/room-types/**";
     private static final String DEPARTMENTS_ENDPOINT = "/departments/**";
     //PUBLIC
-    private static final String SCHEDULE_FOR_USERS_ENDPOINT = "/schedules/full/*";
-    private static final String GROUPS_BY_SEMESTER_ID_PUBLIC_ENDPOINT = "/semesters/{semesterId}/groups";
-    private static final String GROUPS_FOR_CURRENT_SEMESTER_PUBLIC_ENDPOINT = "/semesters/current/groups";
-    private static final String GROUPS_FOR_DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/semesters/default/groups";
-    private static final String ALL_TEACHERS_PUBLIC_ENDPOINT = "/public/teachers";
-    private static final String ALL_CLASSES_PUBLIC_ENDPOINT = "/public/classes";
-    private static final String ALL_SEMESTERS_PUBLIC_ENDPOINT = "/public/semesters";
-    private static final String DOWNLOAD_SCHEDULE_ENDPOINT = "/download/**";
-    private static final String DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/semesters/default";
+    private static final String SCHEDULE_FOR_USERS_ENDPOINT = "/api/schedules/full/*";
+    private static final String GROUPS_BY_SEMESTER_ID_PUBLIC_ENDPOINT = "/api/semesters/{semesterId}/groups";
+    private static final String GROUPS_FOR_CURRENT_SEMESTER_PUBLIC_ENDPOINT = "/api/semesters/current/groups";
+    private static final String GROUPS_FOR_DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/api/semesters/default/groups";
+    private static final String ALL_TEACHERS_PUBLIC_ENDPOINT = "/api/public/teachers";
+    private static final String ALL_CLASSES_PUBLIC_ENDPOINT = "/api/public/classes";
+    private static final String ALL_SEMESTERS_PUBLIC_ENDPOINT = "/api/public/semesters";
+    private static final String DOWNLOAD_SCHEDULE_ENDPOINT = "/api/download/**";
+    private static final String DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/api/semesters/default";
     //FRONTEND
     private static final String HOME_ENDPOINT = "/";
     private static final String LOGIN_ENDPOINT = "/login";

--- a/backend/backend/src/main/java/com/softserve/controller/DownloadFileController.java
+++ b/backend/backend/src/main/java/com/softserve/controller/DownloadFileController.java
@@ -25,7 +25,7 @@ import java.util.Locale;
 @AllArgsConstructor
 @RestController
 @Api(tags = "Download files API")
-@RequestMapping("/download")
+@RequestMapping(path = {"/download", "/api/download"})
 @Slf4j
 public class DownloadFileController {
 

--- a/backend/backend/src/main/java/com/softserve/controller/PeriodController.java
+++ b/backend/backend/src/main/java/com/softserve/controller/PeriodController.java
@@ -31,7 +31,7 @@ public class PeriodController {
         this.periodMapper = periodMapper;
     }
 
-    @GetMapping(path = {"/classes", "/public/classes"})
+    @GetMapping(path = {"/classes", "/public/classes", "/api/public/classes"})
     @ApiOperation(value = "Get the list of all classes")
     public ResponseEntity<List<PeriodDTO>> list() {
         log.info("Enter into list of PeriodController");

--- a/backend/backend/src/main/java/com/softserve/controller/ScheduleController.java
+++ b/backend/backend/src/main/java/com/softserve/controller/ScheduleController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RestController
 @Api(tags = "Schedule API")
 @Slf4j
-@RequestMapping("/schedules")
+@RequestMapping(path = {"/schedules", "/api/schedules"})
 public class ScheduleController {
 
     private final ScheduleService scheduleService;

--- a/backend/backend/src/main/java/com/softserve/controller/SemesterController.java
+++ b/backend/backend/src/main/java/com/softserve/controller/SemesterController.java
@@ -39,7 +39,7 @@ public class SemesterController {
         this.groupService = groupService;
     }
 
-    @GetMapping(path = {"/semesters", "/public/semesters"})
+    @GetMapping(path = {"/semesters", "/public/semesters", "/api/public/semesters"})
     @ApiOperation(value = "Get the list of all semesters")
     public ResponseEntity<List<SemesterWithGroupsDTO>> list() {
         log.info("In list ()");
@@ -63,7 +63,7 @@ public class SemesterController {
         return ResponseEntity.status(HttpStatus.OK).body(semesterMapper.semesterToSemesterWithGroupsDTO(semester));
     }
 
-    @GetMapping("/semesters/default")
+    @GetMapping(path = {"/semesters/default", "/api/semesters/default"})
     @ApiOperation(value = "Get default semester")
     public ResponseEntity<SemesterWithGroupsDTO> getDefault() {
         log.info("In getDefault()");
@@ -128,7 +128,7 @@ public class SemesterController {
         return ResponseEntity.status(HttpStatus.OK).body(semesterMapper.semesterToSemesterWithGroupsDTO(semester));
     }
 
-    @GetMapping("/semesters/current/groups")
+    @GetMapping(path = {"/semesters/current/groups", "/api/semesters/current/groups"})
     @ApiOperation(value = "Get the list of all groups for current semester")
     public ResponseEntity<List<GroupDTO>> getGroupsForCurrentSemester() {
         log.info("In getGroupsForCurrentSemester");
@@ -136,7 +136,7 @@ public class SemesterController {
         return ResponseEntity.status(HttpStatus.OK).body(groupMapper.groupsToGroupDTOs(groups));
     }
 
-    @GetMapping("/semesters/default/groups")
+    @GetMapping(path = {"/semesters/default/groups", "/api/semesters/default/groups"})
     @ApiOperation(value = "Get the list of all groups for default semester")
     public ResponseEntity<List<GroupDTO>> getGroupsForDefaultSemester() {
         log.info("In getGroupsForDefaultSemester");
@@ -144,7 +144,7 @@ public class SemesterController {
         return ResponseEntity.status(HttpStatus.OK).body(groupMapper.groupsToGroupDTOs(groups));
     }
 
-    @GetMapping("/semesters/{semesterId}/groups")
+    @GetMapping(path = {"/semesters/{semesterId}/groups", "/api/semesters/{semesterId}/groups"})
     @ApiOperation(value = "Get the list of all groups for semester by id")
     public ResponseEntity<List<GroupDTO>> getGroupsBySemesterId(@PathVariable Long semesterId) {
         log.info("In getGroupsBySemesterId (semesterId =[{}]", semesterId);

--- a/backend/backend/src/main/java/com/softserve/controller/TeacherController.java
+++ b/backend/backend/src/main/java/com/softserve/controller/TeacherController.java
@@ -35,7 +35,7 @@ public class TeacherController {
         this.scheduleService = scheduleService;
     }
 
-    @GetMapping(path = {"/teachers", "/public/teachers"})
+    @GetMapping(path = {"/teachers", "/public/teachers", "/api/public/teachers"})
     @ApiOperation(value = "Get the list of all teachers")
     public ResponseEntity<List<TeacherDTO>> getAll() {
         log.info("Enter into list method");

--- a/backend/backend/src/test/java/com/softserve/config/SecurityConfig.java
+++ b/backend/backend/src/test/java/com/softserve/config/SecurityConfig.java
@@ -72,15 +72,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private static final String DEPARTMENTS_ENDPOINT = "/departments/**";
 
     //PUBLIC ENDPOINTS
-    private static final String SCHEDULE_FOR_USERS_ENDPOINT = "/schedules/full/*";
-    private static final String GROUPS_BY_SEMESTER_ID_PUBLIC_ENDPOINT = "/semesters/{semesterId}/groups";
-    private static final String GROUPS_FOR_CURRENT_SEMESTER_PUBLIC_ENDPOINT = "/semesters/current/groups";
-    private static final String GROUPS_FOR_DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/semesters/default/groups";
-    private static final String ALL_TEACHERS_PUBLIC_ENDPOINT = "/public/teachers";
-    private static final String ALL_CLASSES_PUBLIC_ENDPOINT = "/public/classes";
-    private static final String ALL_SEMESTERS_PUBLIC_ENDPOINT = "/public/semesters";
-    private static final String DOWNLOAD_SCHEDULE_ENDPOINT = "/download/**";
-    private static final String DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/semesters/default";
+    private static final String SCHEDULE_FOR_USERS_ENDPOINT = "/api/schedules/full/*";
+    private static final String GROUPS_BY_SEMESTER_ID_PUBLIC_ENDPOINT = "/api/semesters/{semesterId}/groups";
+    private static final String GROUPS_FOR_CURRENT_SEMESTER_PUBLIC_ENDPOINT = "/api/semesters/current/groups";
+    private static final String GROUPS_FOR_DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/api/semesters/default/groups";
+    private static final String ALL_TEACHERS_PUBLIC_ENDPOINT = "/api/public/teachers";
+    private static final String ALL_CLASSES_PUBLIC_ENDPOINT = "/api/public/classes";
+    private static final String ALL_SEMESTERS_PUBLIC_ENDPOINT = "/api/public/semesters";
+    private static final String DOWNLOAD_SCHEDULE_ENDPOINT = "/api/download/**";
+    private static final String DEFAULT_SEMESTER_PUBLIC_ENDPOINT = "/api/semesters/default";
 
     //FRONTEND ENDPOINTS
     private static final String HOME_ENDPOINT = "/";


### PR DESCRIPTION
## Summary
- add `/api` prefix for public endpoints in `SecurityConfig`
- update tests to match new endpoint prefixes
- expose `/api` prefixed routes in Semester, Schedule, Period, Teacher and Download controllers

## Testing
- `gradle test -q` *(fails: Plugin [id: 'org.sonarqube'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882aee92a3c832c8f1da9bbe27cb62e